### PR TITLE
Lower the severity of errors to 'warning'.

### DIFF
--- a/flycheck-google-cpplint.el
+++ b/flycheck-google-cpplint.el
@@ -129,7 +129,7 @@ See URL
             (option "--linelength=" flycheck-googlelint-linelength)
             source-original)
   :error-patterns
-  ((error line-start (file-name) ":" line ":  " (message) line-end))
+  ((warning line-start (file-name) ":" line ":  " (message) line-end))
   :modes (c-mode c++-mode))
 
 (add-to-list 'flycheck-checkers 'c/c++-googlelint 'append)


### PR DESCRIPTION
`cpplint.py` checks if source code is in compliance with Google C++ style guide, so `warning` seems to be a more appropriate level than `error`.
