### PR TITLE
Add support for cpplint.py extensions flag

### DIFF
--- a/flycheck-google-cpplint.el
+++ b/flycheck-google-cpplint.el
@@ -93,7 +93,7 @@ root=subdir
   ignored.
 
   Examples:
-    Assuing that src/.git exists, the header guard CPP variables for
+    Assuming that src/.git exists, the header guard CPP variables for
     src/chrome/browser/ui/browser.h are:
 
     No flag => CHROME_BROWSER_UI_BROWSER_H_
@@ -120,7 +120,7 @@ linelength=digits
   "The valid file extensions passed to the Google C++ lint.
 
 extensions=x,y,z
-  This is a comma separated list with allowed file extensions. The default value is
+  This is a comma-separated list with allowed file extensions. The default value is
   `cc, h, cpp, cu, cuh'.
 
   Examples:

--- a/flycheck-google-cpplint.el
+++ b/flycheck-google-cpplint.el
@@ -116,6 +116,19 @@ linelength=digits
   :safe #'stringp
   :package-version '(flycheck . "0.18"))
 
+(flycheck-def-option-var flycheck-googlelint-extensions nil c/c++-googlelint
+  "The valid file extensions passed to the Google C++ lint.
+
+extensions=x,y,z
+  This is a comma separated list with allowed file extensions. The default value is
+  `cc, h, cpp, cu, cuh'.
+
+  Examples:
+    --extensions=cc,h,cpp,cu,cuh"
+  :type '(string :tag "Extensions")
+  :safe #'stringp
+  :package-version '(flycheck . "0.23"))
+
 (flycheck-define-checker c/c++-googlelint
   "A C/C++ style checker using google cpplint.
 
@@ -127,6 +140,7 @@ See URL
                     flycheck-option-comma-separated-list)
             (option "--root=" flycheck-googlelint-root concat)
             (option "--linelength=" flycheck-googlelint-linelength concat)
+            (option "--extensions=" flycheck-googlelint-extensions concat)
             source-original)
   :error-patterns
   ((warning line-start (file-name) ":" line ":  " (message) line-end))


### PR DESCRIPTION
Introduces a 'flycheck-googlelint-extensions' option that is a comma-separated list. This option is supplied to cpplint.py in addition to the other options.

Also corrects a spelling mistake in the root option description.